### PR TITLE
accept logging level

### DIFF
--- a/loggly/handlers.py
+++ b/loggly/handlers.py
@@ -15,8 +15,8 @@ def bg_cb(sess, resp):
 
 
 class HTTPSHandler(logging.Handler):
-    def __init__(self, url, fqdn=False, localname=None, facility=None):
-        logging.Handler.__init__(self)
+    def __init__(self, url, level=logging.DEBUG, fqdn=False, localname=None, facility=None):
+        logging.Handler.__init__(self, level=level)
         self.url = url
         self.fqdn = fqdn
         self.localname = localname


### PR DESCRIPTION
This allows a logging level to be passed to the log handler on init.

This is useful for the  Loggly handler because the plans are tiered and you may not want to send all your logs to Loggly. 
